### PR TITLE
fix: Fixed an issue getting initial data from the current entity

### DIFF
--- a/admin/src/components/Action/Action.tsx
+++ b/admin/src/components/Action/Action.tsx
@@ -95,7 +95,7 @@ const Action = ({ mode, documentId, entitySlug }) => {
 		try {
 			// Validate data with schema if `publish` mode
 			if (mode === 'publish' && schema) {
-				await schema.validate(entity.initialData, { abortEarly: false });
+				await schema.validate(entity.form.initialValues, { abortEarly: false });
 			}
 
 			// Create of update actie


### PR DESCRIPTION
I had an issue where the `initialData` from the `entity` was `undefined`.

According to the [documentation](https://docs.strapi.io/dev-docs/migration/v4-to-v5/additional-resources/helper-plugin#usecmeditviewdatamanager) we should migrate to use the `form` property to get the initial data.

```ts
// Before
const { initialData, modifiedData, onChange } = useCMEditViewDataManager();

// After
const { form } = useContentManagerContext();

// Here 'initialData' and 'modifiedData' correspond to 'initialValues' and 'values'.
const { initialValues, values, onChange } = form;
```