### PR TITLE
feat: fix entity.slug for finding entity

### DIFF
--- a/admin/src/components/ActionManager/ActionManager.tsx
+++ b/admin/src/components/ActionManager/ActionManager.tsx
@@ -18,14 +18,14 @@ const ActionManagerComponent = ({ document, entity }) => {
 	const { isLoading, data, isRefetching } = getSettings();
 
 	useEffect(() => {
-		if (! isLoading && ! isRefetching) {
-			if (! data.contentTypes?.length || data.contentTypes?.find((uid) => uid === document.model)) {
+		if (!isLoading && !isRefetching) {
+			if (!data.contentTypes?.length || data.contentTypes?.find((uid) => uid === entity.slug)) {
 				setShowActions(true);
 			}
 		}
-	}, [isLoading, isRefetching, data, document]);
+	}, [isLoading, isRefetching]);
 
-	if (! showActions) {
+	if (!showActions) {
 		return null;
 	}
 


### PR DESCRIPTION
What does it do?
-Fix find entity based on slug when config is set as example:
'contentTypes': ['api::article.article'],

Why is it needed?
-Fix for making publisher visible when config is set

How to test?
update your plugin.ts config with something like: 'contentTypes': ['api::article.article'],