### PR TITLE
Add Publishing Timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ module.exports = ({ env }) => ({
 | Property                         | Description                                                                      | Type     | Default | Required |
 |----------------------------------|----------------------------------------------------------------------------------|----------| ------- | -------- |
 | actions                          | Settings associated with any actions.                                            | Object   | {} | No |
+| actions.defaultTimezone            | The default IANA timezone for publishing               | String   | 'UTC' | No |
 | actions.syncFrequency            | The frequency to check for actions to run. It is a cron expression               | String   | '*/1 * * * *' | No |
 | components                       | Settings associated with any of the plugins components                           | Object   | {} | No |
 | components.dateTimePicker        | Settings associated with the DateTimePicker component used to set action times   | Object   | {} | No |

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     },
     "maintainers": [
         {
-            "name": "@PluginPal",
-            "url": "https://github.com/PluginPal"
+            "name": "@sungkhum",
+            "url": "https://github.com/sungkhum"
         }
     ],
     "homepage": "https://github.com/sungkhum/strapi-plugin-publisher/#readme",
@@ -75,8 +75,8 @@
         "styled-components": "^6.0.0"
     },
     "strapi": {
-        "displayName": "Publisher",
-        "name": "publisher",
+        "displayName": "Publisher with Timezone",
+        "name": "publishertimezone",
         "description": "A plugin for Strapi Headless CMS that provides the ability to schedule publishing for any content type with default timezone.",
         "kind": "plugin"
     },

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://json.schemastore.org/package",
-    "name": "strapi-plugin-publisher",
-    "version": "2.0.0-beta.10",
-    "description": "A plugin for Strapi Headless CMS that provides the ability to schedule publishing for any content type.",
+    "name": "strapi-plugin-publisher-timezone",
+    "version": "1.0",
+    "description": "A plugin for Strapi Headless CMS that provides the ability to schedule publishing for any content type that includes default timezone.",
     "scripts": {
         "lint": "eslint . --fix",
         "format": "prettier --write **/*.{ts,js,json,yml}",
@@ -35,13 +35,13 @@
             "url": "https://github.com/PluginPal"
         }
     ],
-    "homepage": "https://github.com/PluginPal/strapi-plugin-publisher#readme",
+    "homepage": "https://github.com/sungkhum/strapi-plugin-publisher/#readme",
     "repository": {
         "type": "git",
-        "url": "https://github.com/PluginPal/strapi-plugin-publisher.git"
+        "url": "https://github.com/sungkhum/strapi-plugin-publisher.git"
     },
     "bugs": {
-        "url": "https://github.com/PluginPal/strapi-plugin-publisher/issues"
+        "url": "https://github.com/sungkhum/strapi-plugin-publisher/issues"
     },
     "dependencies": {
         "lodash": "^4.17.21",
@@ -77,7 +77,7 @@
     "strapi": {
         "displayName": "Publisher",
         "name": "publisher",
-        "description": "A plugin for Strapi Headless CMS that provides the ability to schedule publishing for any content type.",
+        "description": "A plugin for Strapi Headless CMS that provides the ability to schedule publishing for any content type with default timezone.",
         "kind": "plugin"
     },
     "engines": {

--- a/server/config/cron-tasks.js
+++ b/server/config/cron-tasks.js
@@ -5,7 +5,10 @@ const registerCronTasks =  ({ strapi }) => {
 	// create cron check
 	strapi.cron.add({
 		publisherCronTask: {
-			options: settings.actions.syncFrequency,
+			options: {
+				rule: settings.actions.syncFrequency,
+				tz: settings.actions.defaultTimezone,
+			  },
 			task: async () => {
 				// fetch all actions that have passed
 				const records = await getPluginService('action').find({

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -5,6 +5,7 @@ export default {
 		enabled: true,
 		actions: {
 			syncFrequency: '*/1 * * * *',
+			defaultTimezone: 'UTC',
 		},
 		hooks: {
 			beforePublish: () => {},

--- a/server/config/schema.js
+++ b/server/config/schema.js
@@ -5,7 +5,7 @@ const pluginConfigSchema = yup.object().shape({
 		.object()
 		.shape({
 			syncFrequency: yup.string().optional(),
-			defaultTimezone: yup.string().nullable(),
+			defaultTimezone: yup.string().optional(),
 		})
 		.optional(),
 	hooks: yup.object().optional(),

--- a/server/config/schema.js
+++ b/server/config/schema.js
@@ -5,6 +5,7 @@ const pluginConfigSchema = yup.object().shape({
 		.object()
 		.shape({
 			syncFrequency: yup.string().optional(),
+			defaultTimezone: yup.string().nullable(),
 		})
 		.optional(),
 	hooks: yup.object().optional(),


### PR DESCRIPTION
I wanted to be able to set the timezone for when content is published rather than just the server set time (which is normally UTC). This allows for adding a default timezone as follows:

```module.exports = ({ env }) => ({
  // …
  publisher: {
    enabled: true,
    config: {
      actions: {
        syncFrequency: '*/1 * * * *',
        defaultTimezone: 'America/Los_Angeles',
      },
      hooks: {
        beforePublish: async ({ strapi, uid, entity }) => {
          console.log('beforePublish');
        },
        afterPublish: async ({ strapi, uid, entity }) => {
          console.log('afterPublish');
        },
        beforeUnpublish: async ({ strapi, uid, entity }) => {
          console.log('beforeUnpublish');
        },
        afterUnpublish: async ({ strapi, uid, entity }) => {
          console.log('afterUnpublish');
        },
      },
    },
  },
  // …
});
```

I've tested this in production, but just by hacking the built files (I was having trouble getting things to build correctly with my forked repo to be used with Strapi v5). So the code should be tested before it is merged.


Hope it is useful to others!