### PR TITLE
Feature/sidebar panel

### DIFF
--- a/admin/src/components/ActionManager/ActionManager.tsx
+++ b/admin/src/components/ActionManager/ActionManager.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useIntl } from 'react-intl';
+import type { PanelComponent } from '@strapi/content-manager/strapi-admin';
 import { Box, Typography, Divider } from '@strapi/design-system';
 import Action from '../Action';
 import { getTrad } from '../../utils/getTrad';
@@ -9,10 +10,16 @@ import {
 	unstable_useDocument as useDocument,
 	unstable_useContentManagerContext as useContentManagerContext,
 } from '@strapi/strapi/admin';
+import { Modules } from '@strapi/strapi';
 
 const actionModes = ['publish', 'unpublish'];
 
-const ActionManagerComponent = ({ document, entity }) => {
+type Props = {
+	document: Modules.Documents.AnyDocument,
+	entity: ReturnType<typeof useContentManagerContext>,
+}
+
+const ActionManagerComponent = ({ document, entity }: Props) => {
 	const { formatMessage } = useIntl();
 	const [showActions, setShowActions] = useState(false);
 	const { getSettings } = useSettings();
@@ -64,7 +71,7 @@ const ActionManagerComponent = ({ document, entity }) => {
 	);
 };
 
-const ActionManager = () => {
+const ActionManager: PanelComponent = () => {
 	const entity = useContentManagerContext();
 	const { document } = useDocument({
 		documentId: entity?.id,

--- a/admin/src/components/ActionManager/ActionManager.tsx
+++ b/admin/src/components/ActionManager/ActionManager.tsx
@@ -42,18 +42,6 @@ const ActionManagerComponent = ({ document, entity }) => {
 
 	return (
 		<>
-			<Box marginTop={2} marginBottom={4}>
-				<Divider />
-			</Box>
-			<Typography variant="sigma" textColor="neutral600">
-				{formatMessage({
-					id: getTrad('plugin.name'),
-					defaultMessage: 'Publisher',
-				})}
-			</Typography>
-			<Box marginTop={2}>
-				<Divider />
-			</Box>
 			{actionModes.map((mode, index) => (
 				<div className="actionButton" key={index}>
 					<Action
@@ -92,7 +80,10 @@ const ActionManager = () => {
 		return null;
 	}
 
-	return <ActionManagerComponent document={document} entity={entity} />;
+	return {
+		title: "Publisher",
+		content: <ActionManagerComponent document={document} entity={entity} />,
+	}
 };
 
 export default ActionManager;

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -17,11 +17,7 @@ export default {
 	},
 
 	bootstrap(app: any) {
-		app.getPlugin('content-manager').injectComponent(
-			'editView',
-			'right-links',
-			{ name: 'action-manager', Component: ActionManager },
-		);
+		app.getPlugin('content-manager').apis.addEditViewSidePanel([ActionManager]);
 	},
 
 	async registerTrads(app: any) {


### PR DESCRIPTION
Addresses #179

Put's the publisher buttons into it's own sidebar panel by using the `addEditViewSidePanel` api from the content-manager plugin.

**Before:**
<img width="282" alt="Scherm­afbeelding 2025-06-08 om 10 53 38" src="https://github.com/user-attachments/assets/59ff5629-dc9f-4d78-a995-39364d5f4332" />

**After:**
<img width="286" alt="Scherm­afbeelding 2025-06-08 om 10 53 23" src="https://github.com/user-attachments/assets/20067b57-f3bc-4111-921e-336f5f3d0524" />
