### PR TITLE
Feature/fix i18n issue

### DIFF
--- a/admin/src/components/ActionManager/ActionManager.tsx
+++ b/admin/src/components/ActionManager/ActionManager.tsx
@@ -17,17 +17,14 @@ const actionModes = ['publish', 'unpublish'];
 type Props = {
 	document: Modules.Documents.AnyDocument,
 	entity: ReturnType<typeof useContentManagerContext>,
+	locale: string | null,
 }
 
-const ActionManagerComponent = ({ document, entity }: Props) => {
+const ActionManagerComponent = ({ document, entity, locale }: Props) => {
 	const { formatMessage } = useIntl();
 	const [showActions, setShowActions] = useState(false);
 	const { getSettings } = useSettings();
 	const { isLoading, data, isRefetching } = getSettings();
-
-	const location = useLocation();
-	const params = new URLSearchParams(location.search);
-	const currentLocale = params.get('plugins[i18n][locale]');
 
 	useEffect(() => {
 		if (!isLoading && !isRefetching) {
@@ -50,7 +47,7 @@ const ActionManagerComponent = ({ document, entity }: Props) => {
 						key={mode + index}
 						documentId={document.documentId}
 						entitySlug={entity.model}
-						locale={localizedEntry.locale}
+						locale={locale}
 					/>
 				</div>
 			))}
@@ -67,10 +64,17 @@ const ActionManagerComponent = ({ document, entity }: Props) => {
 
 const ActionManager: PanelComponent = () => {
 	const entity = useContentManagerContext();
+	const location = useLocation();
+	const params = new URLSearchParams(location.search);
+	const currentLocale = params.get('plugins[i18n][locale]');
+
 	const { document } = useDocument({
 		documentId: entity?.id,
 		model: entity?.model,
 		collectionType: entity?.collectionType,
+		params: {
+			locale: currentLocale,
+		}
 	});
 
 	if (! entity.hasDraftAndPublish || entity.isCreatingEntry) {
@@ -83,7 +87,7 @@ const ActionManager: PanelComponent = () => {
 
 	return {
 		title: "Publisher",
-		content: <ActionManagerComponent document={document} entity={entity} />,
+		content: <ActionManagerComponent document={document} entity={entity} locale={currentLocale} />,
 	}
 };
 

--- a/admin/src/components/ActionManager/ActionManager.tsx
+++ b/admin/src/components/ActionManager/ActionManager.tsx
@@ -41,12 +41,6 @@ const ActionManagerComponent = ({ document, entity }: Props) => {
 		return null;
 	}
 
-	const localizedEntry = [document, ...(document.localizations || [])].find(
-		(entry) => entry.locale === currentLocale
-	);
-
-	if (!localizedEntry) return null;
-
 	return (
 		<>
 			{actionModes.map((mode, index) => (


### PR DESCRIPTION
Addresses #188

This PR does two things:
1. Make sure to add the locale to the `useDocument` hook
2. Remove [this if statement](https://github.com/pluginpal/strapi-plugin-publisher/compare/feature/fix-i18n-issue?expand=1#diff-c95563e939c24d9e0994c00754bdb53c0367e58cbbd5325b1cc5b645adbf7ea1L44-L49) so that the publisher sidebar also shows for documents which do not have a localization in the default locale.

I'm only wondering about the solution for **2**, what was that if statement for? 
@TMSchipper maybe you can confirm that I'm not overlooking some use case of the i18n implementation in this plugin.